### PR TITLE
Make help regex strict

### DIFF
--- a/botCommands/help.js
+++ b/botCommands/help.js
@@ -1,6 +1,6 @@
 const { registerBotCommand } = require("../bot-engine.js");
 
-registerBotCommand(/\/help/, ({ room }) => {
+registerBotCommand(/\/help\b/, ({ room }) => {
   return `> #Odin-Bot Commands
     > - **By posting in this chatroom you agree to our [code of conduct](https://github.com/TheOdinProject/theodinproject/blob/master/doc/code_of_conduct.md)**
     > - give points to someone who has been helpful by mentioning their name and adding ++ : \`@username ++\` or by giving them a star : \`@username :star:\`


### PR DESCRIPTION
Currently, the help command is triggered in texts which contain the substring `'/help'`. The PR fixes it by strictly looking for `/help`.

@codyloyd This is really minor. Should we also make it case-sensitive and ignore whitespaces at the beginning and at the end? What do you think?