### PR TITLE
Update command matching regexes

### DIFF
--- a/botCommands/help.js
+++ b/botCommands/help.js
@@ -1,6 +1,6 @@
 const {registerBotCommand} = require("../botEngine.js");
 
-registerBotCommand(/\B\/help\b/, ({room}) => {
+registerBotCommand(/^\/help\b/, ({room}) => {
   return `
   **By posting in this chatroom you agree to our code of conduct:** <https://github.com/TheOdinProject/theodinproject/blob/master/doc/code_of_conduct.md>
 
@@ -16,7 +16,7 @@ Motivate your fellow odinites with \`/motivate\` and mention them
 I'm open source!  Hack me HERE: <https://github.com/codyloyd/odin-bot-v2>`;
 });
 
-registerBotCommand(/\B\/code\b/, ({room}) => {
+registerBotCommand(/^\/code\b/, ({room}) => {
   return `
 **HOW TO EMBED CODE SNIPPETS**
 To write multiple lines of code use three backticks <https://i.stack.imgur.com/ETTnT.jpg> (on their own line, \`shift + enter\` makes new lines):

--- a/botCommands/points.js
+++ b/botCommands/points.js
@@ -104,7 +104,7 @@ async function pointsBotCommand({ author, content, channel, client }) {
 
 registerBotCommand(AWARD_POINT_REGEX, pointsBotCommand);
 
-registerBotCommand(/\/points/, async function({
+registerBotCommand(/^\/points/, async function({
   content,
   client,
   channel,
@@ -123,7 +123,7 @@ registerBotCommand(/\/points/, async function({
   });
 });
 
-registerBotCommand(/\/leaderboard/, async function({ guild, content }) {
+registerBotCommand(/^\/leaderboard/, async function({ guild, content }) {
   try {
     const users = await axios.get(
       `https://odin-points-bot-discord.herokuapp.com/users`
@@ -157,7 +157,7 @@ registerBotCommand(/\/leaderboard/, async function({ guild, content }) {
   }
 });
 
-registerBotCommand(/\/setpoints/, async function({ author, content }) {
+registerBotCommand(/^\/setpoints/, async function({ author, content }) {
   if (author.id == 418918922507780096) {
     const id = content
       .split(" ")

--- a/botCommands/shrug.js
+++ b/botCommands/shrug.js
@@ -1,6 +1,6 @@
 const {registerBotCommand} = require("../botEngine.js");
 
-registerBotCommand(/\/[shurg]{5}/, ({content}) => {
+registerBotCommand(/^\/[shurg]{5}/, ({content}) => {
   function onlyUnique(value, index, self) {
     return self.indexOf(value) === index;
   }

--- a/botCommands/simpleCommands.js
+++ b/botCommands/simpleCommands.js
@@ -1,17 +1,17 @@
 const {registerBotCommand} = require('../botEngine.js');
 
-registerBotCommand(/\/hug/, () => `⊂(´・ω・｀⊂)`);
+registerBotCommand(/^\/hug/, () => `⊂(´・ω・｀⊂)`);
 
-registerBotCommand(/\/smart/, () => String.raw`f(ಠ‿↼)z`);
+registerBotCommand(/^\/smart/, () => String.raw`f(ಠ‿↼)z`);
 
-registerBotCommand(/\/lenny/, () => String.raw`( ͡° ͜ʖ ͡°)`);
+registerBotCommand(/^\/lenny/, () => String.raw`( ͡° ͜ʖ ͡°)`);
 
 registerBotCommand(/:fu:/, ({ data }) => {
   const user = data.fromUser.username;
   return `@${user} \n ![Not Nice](http://media.riffsy.com/images/636a97aa416ad674eb2b72d4a6e9ad6c/tenor.gif)`;
 });
 
-registerBotCommand(/\/sexpresso/, () => `https://i.gifer.com/8EC5.gif`);
+registerBotCommand(/^\/sexpresso/, () => `https://i.gifer.com/8EC5.gif`);
 
 registerBotCommand(/\peen/, ({author}) => {
   if (author.id == 418918922507780096) {
@@ -19,7 +19,7 @@ registerBotCommand(/\peen/, ({author}) => {
   }
 });
 
-registerBotCommand(/\B\/google\s+.+/, ({content}) => {
+registerBotCommand(/^\/google\s+.+/, ({content}) => {
   const transform = content => {
     const query = content.split(' ').map(encodeURIComponent).join('+');
     return `**HERE YOU GO BABY >** <https://lmgtfy.com/?q=${query}>`;
@@ -29,22 +29,22 @@ registerBotCommand(/\B\/google\s+.+/, ({content}) => {
   return `${transform(query)}`;
 });
 
-registerBotCommand(/\/dab/, () => `https://tenor.com/view/bettywhite-dab-gif-5044603`);
+registerBotCommand(/^\/dab/, () => `https://tenor.com/view/bettywhite-dab-gif-5044603`);
 
 registerBotCommand(
-  /\/gandalf/,
+  /^\/gandalf/,
   () => `http://emojis.slackmojis.com/emojis/images/1450458362/181/gandalf.gif`
 );
 
 
-registerBotCommand(/\/motivate/, () => {
+registerBotCommand(/^\/motivate/, () => {
   return `Don't give up! https://www.youtube.com/watch?v=KxGRhd_iWuE`;
 });
 
-registerBotCommand(/\/justdoit/, () => {
+registerBotCommand(/^\/justdoit/, () => {
   return `What are you waiting for?! https://www.youtube.com/watch?v=ZXsQAXx_ao0`;
 });
 
-registerBotCommand(/\/pairs/, () => {
+registerBotCommand(/^\/pairs/, () => {
   return `**Find your coding partner here:** https://forum.theodinproject.com/c/pairs`;
 });


### PR DESCRIPTION
Some of the command matching regexes are faulty. For instance the code command matches https://code.visualstudio.com/. The help command also matches some urls, see https://github.com/codyloyd/odin-bot-v2/issues/31#issue-579223298.

I modified the regexes where I deemed it appropriate to not mismatch.